### PR TITLE
Edit format of webpage comparison answers

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,23 +145,29 @@
     <a href="http://www.fanpop.com/clubs/inglourious-basterds">Here</a> is a link to the <em>Inglourious Basterds</em> page on Fanpop.com. 
   </p>
     <li>What makes this site good or bad?
-      <p>
-        The site is includes a neat, user-responsive navigation bar, an image gallery, and a comment section. Furthermore, the different sections of the page are visually separated from each other using CSS.
-      </p>
+      <ul type="none">
+        <li>
+          The site is includes a neat, user-responsive navigation bar, an image gallery, and a comment section. Furthermore, the different sections of the page are visually separated from each other using CSS.
+        </li>
+      </ul>
     </li>
     <li>Look at the source code. Do you recognize any HTML elements?
-      <p>
+      <ul type="none">
+        <li>
         I recognize many HTML tags like <code>title</code>, <code>div</code>, <code>img</code>, <code>nav</code>, <code>ul</code>, <code>h1</code>, <code>h2</code>, <code>table</code>, <code>form</code>, <code>input</code> ...
-      </p>
+        </li>
+      </ul>
     </li>
     <li>Try to guess what the things you don't recognize do.
-      <p>
+      <ul type="none">
+        <li>
         The <code>script</code> tag seems to be related to Javacsript elements.<br>
         The <code>link</code> tag seems to be related to applying CSS stylesheets to a webpage.<br>
         The <code>class</code> attribute in many tags seems to be related to styling certain tags with CSS.<br>
         The <code>style</code> attribute in many tags seems to be related to styling specified tags with CSS.<br>
         The <code>cellpadding</code> attribute in the <code>table</code> tag seems to be related to how much padding individual cells have in a table.
-      </p>
+        </li>
+      </ul>
     </li>
 </body>
 </html>


### PR DESCRIPTION
Made it so that the answers to the required questions were indented, for easier readability

For this, I used nested lists. I discovered the `type` attribute that can be added to list tags like `ul`, `ol`, to change the appearance of bullets in the lists.

Example values for the `type` attribute:
- `none`: makes bullets invisible
- `square`: makes bullets in `ul` invisible
- `I`: makes bullets into roman numerals in `ol`
- `i`: makes bullets into lowercase roman numberals in `ol`
- `A`: makes bullets into uppercase letters in `ol`
- `a`makes bullets into lowercase letters in `ol`

Bonus note: You can also add the `start` attribute in `ol` if you want to start your list at a number that's not 1, or a letter that's not a, for example.
